### PR TITLE
Increase force wait time in restart

### DIFF
--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
@@ -391,9 +391,9 @@ public class ServerConfigurationManager {
             ServerAdminClient serverAdmin = new ServerAdminClient(backEndUrl, sessionCookie);
             serverAdmin.restartGracefully();
             try {
-                Thread.sleep(25000); //force wait until server gracefully shutdown
+                Thread.sleep(60000); //force wait until server gracefully shutdown
                 ClientConnectionUtil.waitForPort(port, timeout, true, hostname);
-                Thread.sleep(5000); //forceful wait until server is ready to be served
+                Thread.sleep(120000); //forceful wait until server is ready to be served
             } catch (InterruptedException e) {
                 /* ignored */
             }


### PR DESCRIPTION
## Purpose
> The server takes nearly three minutes to restart and ready to be served. But the system specified the force wait time to less than one minute. Therefore, tests getting failed due to the slowness of the server.

## Goals
> Increase the force wait time.

## Approach
> Increase force wait time in both restart time and server ready time to wait for 3 minutes.

## Automation tests
 - Integration tests
   
## Test environment
> OS: Windows 2016
    DB: Mysql 5.7
    JDK: ORACLE_JDK 8
