### PR TITLE
overloaded method added for copy to component dropins

### DIFF
--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
@@ -522,6 +522,21 @@ public class ServerConfigurationManager {
     }
 
     /**
+     * /**
+     * Copy Jar file to server component/dropins when carbonHome provided
+     *
+     * @param jar jar file
+     * @param carbonHome resident carbon home
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public void copyToComponentDropins(File jar,String carbonHome) throws IOException, URISyntaxException {
+        String lib = carbonHome + File.separator + "repository" + File.separator + "components" + File.separator
+                + "dropins";
+        FileManager.copyJarFile(jar, lib);
+    }
+
+    /**
      * @param fileName file name
      * @throws IOException
      * @throws URISyntaxException

--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
@@ -522,17 +522,16 @@ public class ServerConfigurationManager {
     }
 
     /**
-     * /**
-     * Copy Jar file to server component/dropins when carbonHome provided
+     * Copy Jar file to server component/dropins when carbonHome provided.
      *
-     * @param jar jar file
-     * @param carbonHome resident carbon home
+     * @param jar        Jar file.
+     * @param carbonHome Resident carbon home.
      * @throws IOException
      * @throws URISyntaxException
      */
-    public void copyToComponentDropins(File jar,String carbonHome) throws IOException, URISyntaxException {
-        String lib = carbonHome + File.separator + "repository" + File.separator + "components" + File.separator
-                + "dropins";
+    public void copyToComponentDropins(File jar, String carbonHome) throws IOException, URISyntaxException {
+        String lib =
+                carbonHome + File.separator + "repository" + File.separator + "components" + File.separator + "dropins";
         FileManager.copyJarFile(jar, lib);
     }
 


### PR DESCRIPTION
## Purpose
> resident carbon home that is relevant to the testcase can be different than the one picked by the default method

## Approach
> Added a overloaded version to copyToComponentDropins that can pass carbonHome as a parameter
