### PR TITLE
Remove the 2 mins sleep after server restart

### DIFF
--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/ClientConnectionUtil.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/ClientConnectionUtil.java
@@ -102,6 +102,48 @@ public class ClientConnectionUtil {
     }
 
     /**
+     * @param port    The port that needs to be checked
+     * @param timeout The timeout waiting for the port to close
+     * @param verbose if verbose is set to true,
+     * @throws RuntimeException if the port is not closed within the {@link #TIMEOUT}
+     */
+    public static void waitForPortClose(int port, long timeout, boolean verbose, String hostName)
+            throws RuntimeException {
+        long startTime = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - startTime) < timeout) {
+            Socket socket = null;
+            try {
+                InetAddress address = InetAddress.getByName(hostName);
+                socket = new Socket(address, port);
+                if (socket.isConnected()) {
+                    if (verbose) {
+                        log.info("Waiting until server shutdown and close port " + port);
+                    }
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+            } catch (IOException e) {
+                // IO exception means the endpoint is not reachable.
+                if (verbose) {
+                    log.info("Server port " + port + " is no longer open.");
+                }
+                return;
+            } finally {
+                try {
+                    if ((socket != null) && (socket.isConnected())) {
+                        socket.close();
+                    }
+                } catch (IOException e) {
+                    log.error("Can not close the socket with is used to check the server status ", e);
+                }
+            }
+        }
+        throw new RuntimeException("Port " + port + " is not closed");
+    }
+
+    /**
      * Checks whether the given <code>port</code> is open, and waits for sometime until the port is
      * open. If the port is not open within {@link #TIMEOUT}, throws RuntimeException.
      *

--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/ClientConnectionUtil.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/ClientConnectionUtil.java
@@ -30,6 +30,7 @@ import java.net.Socket;
 public class ClientConnectionUtil {
     private static final Log log = LogFactory.getLog(ClientConnectionUtil.class);
     private static final long TIMEOUT = 180000;
+    private static final long LOGIN_TIMEOUT = 300000;
 
     /**
      * Wait for sometime until it is possible to login to the Carbon server
@@ -38,7 +39,7 @@ public class ClientConnectionUtil {
             throws MalformedURLException, LoginAuthenticationExceptionException {
         long startTime = System.currentTimeMillis();
         boolean loginFailed = true;
-        while (((System.currentTimeMillis() - startTime) < TIMEOUT) && loginFailed) {
+        while (((System.currentTimeMillis() - startTime) < LOGIN_TIMEOUT) && loginFailed) {
             log.info("Waiting to login  user...");
             try {
                 LoginLogoutClient loginClient = new LoginLogoutClient(context);

--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
@@ -390,9 +390,13 @@ public class ServerConfigurationManager {
             ServerAdminClient serverAdmin = new ServerAdminClient(backEndUrl, sessionCookie);
             serverAdmin.restartGracefully();
             try {
-                Thread.sleep(60000); //force wait until server gracefully shutdown
+                // Waiting for the port closure since it can take time to close the port if there server is serving
+                // traffic. Hence after the next thread sleep when it's trying to check the port availability after
+                // server restart, it might be seeing the open port which is not yet closed. So tests needs to wait
+                // until it is confirmed that the server is successfully shut down.
+                ClientConnectionUtil.waitForPortClose(port, timeout, true, hostname);
+                Thread.sleep(40000); //force wait until server gracefully shutdown
                 ClientConnectionUtil.waitForPort(port, timeout, true, hostname);
-                Thread.sleep(120000); //forceful wait until server is ready to be served
             } catch (InterruptedException e) {
                 /* ignored */
             }


### PR DESCRIPTION
## Purpose
> After a server restart, ServerConfigurationManager waits 2 mins before continuing the tests. This will add a significant delay when there are multiple server restarts during the tests.
