### PR TITLE
Fixing unique backup file name issue

### DIFF
--- a/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
+++ b/common-framework-utils/src/main/java/org/wso2/carbon/integration/common/utils/mgt/ServerConfigurationManager.java
@@ -38,7 +38,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.rmi.RemoteException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -103,16 +105,9 @@ public class ServerConfigurationManager {
         if (fileName.contains(AXIS2_XML)) {
             confDir = confDir + "axis2" + File.separator;
         }
-        originalConfig = new File(confDir + fileName);
-        backUpConfig = new File(confDir + fileName + ".backup");
 
-        Files.move(originalConfig.toPath(), backUpConfig.toPath(), StandardCopyOption.REPLACE_EXISTING);
-
-        if (originalConfig.exists()) {
-            throw new IOException("Failed to rename file from " + originalConfig.getName() + "to" + backUpConfig.getName());
-        }
-
-        configDatas.add(new ConfigData(backUpConfig, originalConfig));
+        // Call the backup method with the constructed file path
+        backupConfiguration(new File(confDir + fileName));
     }
 
     /**
@@ -123,7 +118,10 @@ public class ServerConfigurationManager {
     private void backupConfiguration(File file) throws IOException {
         //restore backup configuration
         originalConfig = file;
-        backUpConfig = new File(file.getAbsolutePath() + ".backup");
+
+        // Creating a unique backup file not to conflict with multiple config modifications on the same pack
+        String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
+        backUpConfig = new File(file.getAbsolutePath() + ".backup." + timestamp);
 
         Files.move(originalConfig.toPath(), backUpConfig.toPath(), StandardCopyOption.REPLACE_EXISTING);
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <slf4j.wso2.version>1.5.10.wso2v1</slf4j.wso2.version>
 
         <!-- Automation Framework version-->
-        <test.framework.version>4.4.6</test.framework.version>
+        <test.framework.version>4.4.12</test.framework.version>
         <zip4j.version>1.2.3</zip4j.version>
         <commons-lang3>3.0</commons-lang3>
         <htmlparser.version>2.1</htmlparser.version>


### PR DESCRIPTION
## Purpose
When modifying configurations during integration tests, the backup file name is not unique, for example, `deployment.toml.backup`. 

If multiple scenarios modify the same package, it can result in conflicts when attempting to restore the backup file.
i.e Initialiser test modifies the config before the test block,  A test class modifies the config again and restore, now there is no backup since the same name. Still the restore is required.

Related PR
- https://github.com/wso2/product-is/pull/21277